### PR TITLE
Fixing the link to the image in README.md again, to be absolute, and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ llm -m ati "A parrot."
 If everything is set up correctly, this will generate an image of a parrot, save it as "A_parrot.png" in your
 current file system path, and open it with your operating system’s default image display app:
 
-![A parrot.](https://github.com/zalez/llm-bedrock-titan-image/blob/main/A_parrot.png)
+![A parrot.](https://raw.githubusercontent.com/zalez/llm-bedrock-titan-image/main/A_parrot.png)
 
 If a file with the same name exists already (likely, since this repository has one), this plugin will choose an unused
 version of the filename, like ```A_parrot_1.png```.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-bedrock-titan-image"
-version = "1.0.2"
+version = "1.0.3"
 description = "An LLM plugin for supporting Amazon Titan image generators on Amazon Bedrock."
 readme = "README.md"
 authors = [{name = "Constantin Gonzalez"}]


### PR DESCRIPTION
…to point to the raw image content (not the page) so it also works in PyPi.